### PR TITLE
Update basefee osm bundler

### DIFF
--- a/src/Callers/BasefeeOSMDeviationCallBundler.sol
+++ b/src/Callers/BasefeeOSMDeviationCallBundler.sol
@@ -50,9 +50,6 @@ contract BasefeeOSMDeviationCallBundler is BaseFeeIncentive {
         oracleRelayer = OracleRelayerLike(oracleRelayer_);
         acceptedDeviation = acceptedDeviation_;
 
-        for (uint i; i < 3; i++) {
-            if (collateral_[i] != bytes32(0)) require(oracleRelayer.orcl(collateral_[i]) == osm_, "invalid-collateral");
-        }
         collateralA = collateral_[0];
         collateralB = collateral_[1];
         collateralC = collateral_[2];

--- a/src/Callers/BasefeeOSMDeviationCallBundler.sol
+++ b/src/Callers/BasefeeOSMDeviationCallBundler.sol
@@ -28,7 +28,7 @@ contract BasefeeOSMDeviationCallBundler is BaseFeeIncentive {
     bytes32 public immutable collateralB;
     bytes32 public immutable collateralC;
 
-    uint256 public acceptedDeviation = 50; // 1000 = 100%, default 5%
+    uint256 public acceptedDeviation; // 1000 = 100%
 
     // --- Constructor ---
     constructor(
@@ -39,13 +39,16 @@ contract BasefeeOSMDeviationCallBundler is BaseFeeIncentive {
         uint256 reward_,
         uint256 delay_,
         address coinOracle_,
-        address ethOracle_
+        address ethOracle_,
+        uint256 acceptedDeviation_
     ) BaseFeeIncentive(treasury_, reward_, delay_, coinOracle_, ethOracle_) {
         require(osm_ != address(0), "invalid-osm");
         require(oracleRelayer_ != address(0), "invalid-oracle-relayer");
+        require(acceptedDeviation_ < 1000, "invalid-deviation");
 
         osm = OSMLike(osm_);
         oracleRelayer = OracleRelayerLike(oracleRelayer_);
+        acceptedDeviation = acceptedDeviation_;
 
         for (uint i; i < 3; i++) {
             if (collateral_[i] != bytes32(0)) require(oracleRelayer.orcl(collateral_[i]) == osm_, "invalid-collateral");
@@ -53,11 +56,13 @@ contract BasefeeOSMDeviationCallBundler is BaseFeeIncentive {
         collateralA = collateral_[0];
         collateralB = collateral_[1];
         collateralC = collateral_[2];
+
+        emit ModifyParameters("acceptedDeviation", acceptedDeviation_);
     }
 
     function modifyParameters(bytes32 parameter, uint256 data) public override isAuthorized {
         if (parameter == "acceptedDeviation") {
-            require(data <= 500, "invalid-deviation");
+            require(data < 1000, "invalid-deviation");
             acceptedDeviation = data;
             emit ModifyParameters(parameter, data);
         } else super.modifyParameters(parameter, data);

--- a/test/BasefeeOSMDeviationCallBundler.t.sol
+++ b/test/BasefeeOSMDeviationCallBundler.t.sol
@@ -197,21 +197,6 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
         );
     }
 
-    function testConstructorInvalidCollateral() external {
-        vm.expectRevert("invalid-collateral");
-        bundler = new BasefeeOSMDeviationCallBundler(
-            address(treasury),
-            address(osm),
-            address(oracleRelayer),
-            [bytes32("ETH-A"), "ETH-B", "ETH-D"],
-            1 ether,
-            1 minutes,
-            address(coinOracle),
-            address(ethOracle), 
-            50 // 5%
-        );
-    }
-
     function testConstructorNullReward() external {
         vm.expectRevert("invalid-reward");
         bundler = new BasefeeOSMDeviationCallBundler(

--- a/test/BasefeeOSMDeviationCallBundler.t.sol
+++ b/test/BasefeeOSMDeviationCallBundler.t.sol
@@ -127,7 +127,8 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
             1 ether,
             1 minutes,
             address(coinOracle),
-            address(ethOracle)
+            address(ethOracle),
+            50 // 5%
         );
 
         treasury.setTotalAllowance(address(bundler), type(uint).max);
@@ -148,6 +149,7 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
         assertEq(bundler.collateralA(), bytes32("ETH-A"));
         assertEq(bundler.collateralB(), bytes32("ETH-B"));
         assertEq(bundler.collateralC(), bytes32("ETH-C"));
+        assertEq(bundler.acceptedDeviation(), 50);
     }
 
     function testConstructorNullTreasury() external {
@@ -160,7 +162,8 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
             1 ether,
             1 minutes,
             address(coinOracle),
-            address(ethOracle)
+            address(ethOracle), 
+            50 // 5%
         );
     }
 
@@ -174,7 +177,8 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
             1 ether,
             1 minutes,
             address(coinOracle),
-            address(ethOracle)
+            address(ethOracle), 
+            50 // 5%
         );
     }
 
@@ -188,7 +192,8 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
             1 ether,
             1 minutes,
             address(coinOracle),
-            address(ethOracle)
+            address(ethOracle), 
+            50 // 5%
         );
     }
 
@@ -202,7 +207,8 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
             1 ether,
             1 minutes,
             address(coinOracle),
-            address(ethOracle)
+            address(ethOracle), 
+            50 // 5%
         );
     }
 
@@ -216,7 +222,8 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
             0,
             1 minutes,
             address(coinOracle),
-            address(ethOracle)
+            address(ethOracle), 
+            50 // 5%
         );
     }
 
@@ -230,7 +237,8 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
             1 ether,
             1 minutes,
             address(0),
-            address(ethOracle)
+            address(ethOracle), 
+            50 // 5%
         );
     }
 
@@ -244,9 +252,25 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
             1 ether,
             1 minutes,
             address(coinOracle),
-            address(0)
+            address(0),
+            50 // 5%
         );
     }
+
+    function testConstructorInvalidDeviation() external {
+        vm.expectRevert("invalid-deviation");
+        bundler = new BasefeeOSMDeviationCallBundler(
+            address(treasury),
+            address(osm),
+            address(oracleRelayer),
+            [bytes32("ETH-A"), "ETH-B", "ETH-C"],
+            1 ether,
+            1 minutes,
+            address(coinOracle),
+            address(ethOracle),
+            1000
+        );
+    }    
 
     function testModifyParameters() external {
         bundler.modifyParameters("fixedReward", 2 ether);
@@ -277,7 +301,7 @@ contract BasefeeOSMDeviationCallBundlerTest is Test {
         assertEq(bundler.acceptedDeviation(), 500);
 
         vm.expectRevert("invalid-deviation");
-        bundler.modifyParameters("acceptedDeviation", 501);
+        bundler.modifyParameters("acceptedDeviation", 1000);
     }
 
     function testIncentivizedCall() external {
@@ -389,7 +413,8 @@ function testIncentivizedCallDeviation() external {
             1 ether,
             1 minutes,
             address(coinOracle),
-            address(ethOracle)
+            address(ethOracle), 
+            50 // 5%
         );
 
         vm.prank(address(0x0ddaf));


### PR DESCRIPTION
- Make acceptedDeviation a constructor parameter. (Closes #7 )
- Remove collateral check on constructor, to allow deploying incentives before the collateral is setup in the system